### PR TITLE
Chrome complains when loading http javascript

### DIFF
--- a/inc/header.php
+++ b/inc/header.php
@@ -100,12 +100,12 @@ $gen->checkCronStatus();
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 	<title><?=($pages->title ? $config['app_name'].' '.$config['app_version'].'.'.$config['app_version_minor'].' - '.$pages->title : $config['app_name'].' '.$config['app_version'].'.'.$config['app_version_minor']);?></title>
 
-	<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
-	<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.9.2/jquery-ui.min.js"></script>
+	<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+	<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.9.2/jquery-ui.min.js"></script>
     <script type="text/javascript" src="js/jquery.formatCurrency-1.4.0.min.js"></script>
     <!-- Highcharts, for the stats page -->
-    <script src="http://code.highcharts.com/stock/highstock.js"></script>
-	<script src="http://code.highcharts.com/stock/modules/exporting.js"></script>
+    <script src="https://code.highcharts.com/stock/highstock.js"></script>
+	<script src="https://code.highcharts.com/stock/modules/exporting.js"></script>
 	
     <!-- Bootstrap -->
     <link href="css/bootstrap.min.css" rel="stylesheet">


### PR DESCRIPTION
Chrome complains when loading http javascript when MarginBot is on https. Both ajax.googleapis.com and code.highcharts.com have https, so as far as I can see there are no drawbacks to this change.