### PR TITLE
Issue where every other run will cancel all loan offers but not initiate new ones due to lack of balance

### DIFF
--- a/inc/ExchangeAPIs/bitfinex.php
+++ b/inc/ExchangeAPIs/bitfinex.php
@@ -289,6 +289,11 @@ class Bitfinex{
 				}
 			}
 		}
+		// wait 15 seconds so exchange can update balence
+		sleep(15);
+		// how much we got?
+		// since we just canceled some loans we need to update this
+		$this->bitfinex_getDepositBalance();
 	}
 	
 	
@@ -298,10 +303,6 @@ class Bitfinex{
 		//  then divide it by the $spreadlend account setting to get
 		//  a lend per amount.  If theres a highhold, we subtract
 		//  that from the total and set it aside as a special lend
-		
-		// how much we got?
-		// since we just canceled some loans we need to update this
-		$this->bitfinex_getDepositBalance();
 		
 		$ca = $this->cryptoAvailable[$cur];
 		// if its less than $50, we have nothing to do, since thats the minimum loan //


### PR DESCRIPTION
Balance update should be right after we cancel the pending loans or else outer if statement will use old balance and result in false. bitfinex_getMyLendRate() will never get executed resulting in every other run canceling all loans but not offering new loans. Also added 15 sec sleep as sometimes the exchange will not update your existing balance quickly enough.